### PR TITLE
Fixed "Remote URL" TextBlock. Fixes #109

### DIFF
--- a/OpenHAB.Windows/View/SettingsPage.xaml
+++ b/OpenHAB.Windows/View/SettingsPage.xaml
@@ -44,7 +44,7 @@
                              Margin="0,0,12,12"
                              IsEnabled="{x:Bind CheckBoxDemoMode.IsChecked, Converter={StaticResource ReverseBoolConverter}, Mode=OneWay}"
                              Text="{Binding Settings.OpenHABUrl, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                    <TextBlock Text="openHAB Remote URl" />
+                    <TextBlock Text="openHAB Remote URL" />
                     <TextBox x:Name="TextBoxRemoteUrl"
                              Margin="0,0,12,12"
                              IsEnabled="{x:Bind CheckBoxDemoMode.IsChecked, Converter={StaticResource ReverseBoolConverter}, Mode=OneWay}"


### PR DESCRIPTION
The text was "openHAB Remote URl" (The 'L' was not uppercase as it should be). Fixes #109
Signed-off-by: Luciano Peixoto <lucianopeixoto@hotmail.com> (github: @lucianopeixoto)