### PR TITLE
Issue #115 fix crash on unreachable url, fix Save to reload sitemap

### DIFF
--- a/Openhab.Core/SDK/OpenHAB.cs
+++ b/Openhab.Core/SDK/OpenHAB.cs
@@ -208,6 +208,7 @@ namespace OpenHAB.Core.SDK
             if (isReachable)
             {
                 OpenHABHttpClient.BaseUrl = settings.OpenHABUrl;
+                return true;
             }
             else
             {
@@ -245,6 +246,10 @@ namespace OpenHAB.Core.SDK
                 }
             }
             catch (InvalidOperationException)
+            {
+                return false;
+            }
+            catch (System.Net.Http.HttpRequestException)
             {
                 return false;
             }


### PR DESCRIPTION
Added exception handling for invalid Url
Added code so that an existing URL will get reloaded on Save in Settings. Essentially it becomes a Reload Sitemap action.

Signed-off-by: Gerrit Visser <gerrit@psgv.ca> (github: gerritv)