### PR TITLE
Fixed app crash when command can not be sent to server

### DIFF
--- a/OpenHAB.Windows/Controls/SetpointWidget.xaml.cs
+++ b/OpenHAB.Windows/Controls/SetpointWidget.xaml.cs
@@ -1,6 +1,5 @@
 ﻿using System.Globalization;
 using GalaSoft.MvvmLight.Messaging;
-using OpenHAB.Core.Messages;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Controls;

--- a/OpenHAB.Windows/ErrorMessageTranslator.cs
+++ b/OpenHAB.Windows/ErrorMessageTranslator.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using GalaSoft.MvvmLight.Messaging;
+using Microsoft.Extensions.Logging;
+using Microsoft.Toolkit.Uwp.Connectivity;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using OpenHAB.Core.Common;
+using OpenHAB.Core.Contracts.Services;
+using OpenHAB.Core.Messages;
+using OpenHAB.Core.Model;
+using OpenHAB.Core.Model.Connection;
+
+namespace OpenHAB.Core.SDK
+{
+
+    public class ErrorMessageTranslator
+    {
+        public static void FireUIError(string context, ErrorTypes error, Exception exception)
+        {
+            string message = GetErrorMessageByType(error);
+        }
+
+        private static string GetErrorMessageByType(ErrorTypes error)
+        {
+           string errorMessage = AppResources.Values.GetString(error.ToString());
+
+           return errorMessage;
+        }
+    }
+}

--- a/OpenHAB.Windows/OpenHAB.Windows.csproj
+++ b/OpenHAB.Windows/OpenHAB.Windows.csproj
@@ -118,6 +118,12 @@
     <PRIResource Include="..\Openhab.Core\Strings\en-us\Resources.resw">
       <Link>Strings\en-us\Resources.resw</Link>
     </PRIResource>
+    <PRIResource Include="..\Openhab.Core\Strings\de-de\Errors.resw">
+      <Link>Strings\de-de\Errors.resw</Link>
+    </PRIResource>
+    <PRIResource Include="..\Openhab.Core\Strings\en-us\Errors.resw">
+      <Link>Strings\en-us\Errors.resw</Link>
+    </PRIResource>
     <None Include="OpenHAB.Windows_StoreKey.pfx" />
     <None Include="OpenHAB.Windows_TemporaryKey.pfx" />
   </ItemGroup>
@@ -387,12 +393,6 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\OpenHAB.Core\OpenHAB.Core.csproj">
-      <Project>{2a8fd10e-4ee5-4e25-b47c-2296e071f482}</Project>
-      <Name>OpenHAB.Core</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
     <SDKReference Include="Microsoft.Services.Store.Engagement, Version=10.0">
       <Name>Microsoft Engagement Framework</Name>
     </SDKReference>
@@ -438,6 +438,12 @@
     <PackageReference Include="WinRTXamlToolkit.UWP">
       <Version>2.3.0</Version>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\OpenHAB.Core\OpenHAB.Core.csproj">
+      <Project>{2a8fd10e-4ee5-4e25-b47c-2296e071f482}</Project>
+      <Name>OpenHAB.Core</Name>
+    </ProjectReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>

--- a/OpenHAB.Windows/OpenHAB.Windows.csproj
+++ b/OpenHAB.Windows/OpenHAB.Windows.csproj
@@ -197,6 +197,7 @@
     <Compile Include="Converters\WidgetTemplateSelector.cs" />
     <Compile Include="Converters\ZeroToVisibilityConverter.cs" />
     <Compile Include="DIService.cs" />
+    <Compile Include="ErrorMessageTranslator.cs" />
     <Compile Include="Extensions\Extensions.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="ViewModel\ConfigurationViewModel.cs" />

--- a/OpenHAB.Windows/ViewModel/ConnectionDialogViewModel.cs
+++ b/OpenHAB.Windows/ViewModel/ConnectionDialogViewModel.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using GalaSoft.MvvmLight.Command;
-using Microsoft.Graphics.Canvas.Effects;
 using OpenHAB.Core;
 using OpenHAB.Core.Common;
 using OpenHAB.Core.Contracts;
@@ -267,11 +266,11 @@ namespace OpenHAB.Windows.ViewModel
 
             string url = parameter.ToString();
 
-            Task<bool> result = _openHabsdk.CheckUrlReachability(this.Model);
+            Task<HttpResponseResult<bool>> result = _openHabsdk.CheckUrlReachability(this.Model);
             result.ContinueWith(async (task) =>
             {
                 OpenHABUrlState urlState = OpenHABUrlState.Unknown;
-                if (task.IsCompletedSuccessfully && task.Result)
+                if (task.IsCompletedSuccessfully && task.Result.Content)
                 {
                     urlState = OpenHABUrlState.OK;
                 }

--- a/OpenHAB.Windows/ViewModel/MainViewModel.cs
+++ b/OpenHAB.Windows/ViewModel/MainViewModel.cs
@@ -123,10 +123,10 @@ namespace OpenHAB.Windows.ViewModel
                     if (_selectedSitemap?.Widgets == null || _selectedSitemap?.Widgets.Count == 0)
                     {
                         CoreDispatcher dispatcher = CoreApplication.MainView.CoreWindow.Dispatcher;
-                        dispatcher.RunAsync(CoreDispatcherPriority.Normal,  () =>
-                        {
-                            LoadWidgets();
-                        });
+                        dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+                       {
+                           LoadWidgets();
+                       });
                     }
                     else
                     {
@@ -211,7 +211,14 @@ namespace OpenHAB.Windows.ViewModel
 
         private async Task TriggerCommand(TriggerCommandMessage message)
         {
-            await _openHabsdk.SendCommand(message.Item, message.Command).ConfigureAwait(false);
+            HttpResponseResult<bool> result = await _openHabsdk.SendCommand(message.Item, message.Command).ConfigureAwait(false);
+            if (!result.Content)
+            {
+                string errorMessage = AppResources.Errors.GetString("CommandFailed");
+                errorMessage = string.Format(errorMessage, message.Command, message.Item.Name);
+
+                Messenger.Default.Send<FireErrorMessage>(new FireErrorMessage(errorMessage));
+            }
         }
 
         #endregion

--- a/Openhab.Core/AppResources.cs
+++ b/Openhab.Core/AppResources.cs
@@ -10,7 +10,7 @@ namespace OpenHAB.Core
         private static ResourceLoader _resourceLoader;
 
         /// <summary>
-        ///   Gets the localized languages.
+        ///   Gets the localized UI values.
         /// </summary>
         public static ResourceLoader Values
         {
@@ -19,6 +19,22 @@ namespace OpenHAB.Core
                 if (_resourceLoader == null)
                 {
                     _resourceLoader = ResourceLoader.GetForViewIndependentUse("Resources");
+                }
+
+                return _resourceLoader;
+            }
+        }
+
+        /// <summary>
+        ///   Gets the localized error strings.
+        /// </summary>
+        public static ResourceLoader Errors
+        {
+            get
+            {
+                if (_resourceLoader == null)
+                {
+                    _resourceLoader = ResourceLoader.GetForViewIndependentUse("Errors");
                 }
 
                 return _resourceLoader;

--- a/Openhab.Core/Common/ErrorTypes.cs
+++ b/Openhab.Core/Common/ErrorTypes.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OpenHAB.Core.Common
+{
+    public enum ErrorTypes
+    {
+        UrlNotDefined = 0,
+        HTTPError = 1,
+    }
+}

--- a/Openhab.Core/Common/HttpResponseResult.cs
+++ b/Openhab.Core/Common/HttpResponseResult.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Net;
+
+namespace OpenHAB.Core.Common
+{
+    /// <summary>HTTP response result.</summary>
+    /// <typeparam name="T">Content Type.</typeparam>
+    /// <typeparam name="TS">Error Type.</typeparam>
+    public class HttpResponseResult<T, TS>
+    {
+        /// <summary>Initializes a new instance of the <see cref="HttpResponseResult{T, S}" /> class.</summary>
+        /// <param name="content">The content.</param>
+        /// <param name="error">The error.</param>
+        /// <param name="statusCode">The status code.</param>
+        public HttpResponseResult(T content, TS error, HttpStatusCode? statusCode)
+            : this (content, error, statusCode, null)
+        {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="HttpResponseResult{T, TS}" /> class.</summary>
+        /// <param name="content">The content.</param>
+        /// <param name="error">The error.</param>
+        /// <param name="statusCode">The status code.</param>
+        /// <param name="exception">The exception.</param>
+        public HttpResponseResult(T content, TS error, HttpStatusCode? statusCode, Exception exception)
+        {
+            Content = content;
+            Error = error;
+            StatusCode = statusCode;
+            Exception = exception;
+        }
+
+        /// <summary>Gets the deserailized HTTP response content.</summary>
+        /// <value>Deserailized HTTP response content.</value>
+        public T Content
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>Gets the custom error description.</summary>
+        /// <value>  Error description including error code and details.</value>
+        public TS Error
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// Gets the exception when available.
+        /// </summary>
+        /// <value>
+        /// The exception.
+        /// </value>
+        public Exception Exception
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>Gets the http status code.</summary>
+        /// <value>The status code.</value>
+        public HttpStatusCode? StatusCode
+        {
+            get; private set;
+        }
+    }
+}

--- a/Openhab.Core/Common/HttpResponseResult.cs
+++ b/Openhab.Core/Common/HttpResponseResult.cs
@@ -6,26 +6,23 @@ namespace OpenHAB.Core.Common
     /// <summary>HTTP response result.</summary>
     /// <typeparam name="T">Content Type.</typeparam>
     /// <typeparam name="TS">Error Type.</typeparam>
-    public class HttpResponseResult<T, TS>
+    public class HttpResponseResult<T>
     {
-        /// <summary>Initializes a new instance of the <see cref="HttpResponseResult{T, S}" /> class.</summary>
+        /// <summary>Initializes a new instance of the <see cref="HttpResponseResult{T}" /> class.</summary>
         /// <param name="content">The content.</param>
-        /// <param name="error">The error.</param>
         /// <param name="statusCode">The status code.</param>
-        public HttpResponseResult(T content, TS error, HttpStatusCode? statusCode)
-            : this (content, error, statusCode, null)
+        public HttpResponseResult(T content, HttpStatusCode? statusCode)
+            : this (content, statusCode, null)
         {
         }
 
-        /// <summary>Initializes a new instance of the <see cref="HttpResponseResult{T, TS}" /> class.</summary>
+        /// <summary>Initializes a new instance of the <see cref="HttpResponseResult{T}" /> class.</summary>
         /// <param name="content">The content.</param>
-        /// <param name="error">The error.</param>
         /// <param name="statusCode">The status code.</param>
         /// <param name="exception">The exception.</param>
-        public HttpResponseResult(T content, TS error, HttpStatusCode? statusCode, Exception exception)
+        public HttpResponseResult(T content, HttpStatusCode? statusCode, Exception exception)
         {
             Content = content;
-            Error = error;
             StatusCode = statusCode;
             Exception = exception;
         }
@@ -33,14 +30,6 @@ namespace OpenHAB.Core.Common
         /// <summary>Gets the deserailized HTTP response content.</summary>
         /// <value>Deserailized HTTP response content.</value>
         public T Content
-        {
-            get;
-            private set;
-        }
-
-        /// <summary>Gets the custom error description.</summary>
-        /// <value>  Error description including error code and details.</value>
-        public TS Error
         {
             get;
             private set;

--- a/Openhab.Core/Messages/FireErrorMessage.cs
+++ b/Openhab.Core/Messages/FireErrorMessage.cs
@@ -11,6 +11,16 @@ namespace OpenHAB.Core.Messages
         /// Initializes a new instance of the <see cref="FireErrorMessage"/> class.
         /// </summary>
         /// <param name="errorMessage">The error message.</param>
+        public FireErrorMessage(string errorMessage)
+        {
+            ErrorMessage = errorMessage;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FireErrorMessage"/> class.
+        /// </summary>
+        /// <param name="errorType"></param>
+        /// <param name="errorMessage">The error message.</param>
         public FireErrorMessage(ErrorTypes errorType, string errorMessage)
         {
             ErrorMessage = errorMessage;

--- a/Openhab.Core/Messages/FireErrorMessage.cs
+++ b/Openhab.Core/Messages/FireErrorMessage.cs
@@ -1,4 +1,6 @@
-﻿namespace OpenHAB.Core.Messages
+﻿using OpenHAB.Core.Common;
+
+namespace OpenHAB.Core.Messages
 {
     /// <summary>
     /// Triggers a visual error message.
@@ -9,9 +11,10 @@
         /// Initializes a new instance of the <see cref="FireErrorMessage"/> class.
         /// </summary>
         /// <param name="errorMessage">The error message.</param>
-        public FireErrorMessage(string errorMessage)
+        public FireErrorMessage(ErrorTypes errorType, string errorMessage)
         {
             ErrorMessage = errorMessage;
+            ErrorType = errorType;
         }
 
         /// <summary>
@@ -21,6 +24,13 @@
         public string ErrorMessage
         {
             get; set;
+        }
+
+        /// <summary>Gets the type of the error.</summary>
+        /// <value>The type of the error.</value>
+        public ErrorTypes ErrorType
+        {
+            get;
         }
     }
 }

--- a/Openhab.Core/Openhab.Core.csproj
+++ b/Openhab.Core/Openhab.Core.csproj
@@ -105,12 +105,14 @@
   <ItemGroup>
     <Compile Include="AppResources.cs" />
     <Compile Include="Common\ActionCommand.cs" />
+    <Compile Include="Common\ErrorTypes.cs" />
     <Compile Include="Common\ColorChangedEventArgs.cs" />
     <Compile Include="Common\ColorHelper.cs" />
     <Compile Include="Common\Constants.cs" />
     <Compile Include="Common\DataErrorInfo.cs" />
     <Compile Include="Common\DeviceFamily.cs" />
     <Compile Include="Common\DeviceTypeHelper.cs" />
+    <Compile Include="Common\HttpResponseResult.cs" />
     <Compile Include="Common\ObservableCollectionExtensions.cs" />
     <Compile Include="Model\Connection\CloudConnectionProfile.cs" />
     <Compile Include="Model\Connection\DemoConnectionProfile.cs" />
@@ -150,6 +152,7 @@
     <Compile Include="Common\OpenHABHttpClient.cs" />
     <Compile Include="Model\OpenHabVersion.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SDK\ErrorMessageTranslator.cs" />
     <Compile Include="SDK\IOpenHAB.cs" />
     <Compile Include="SDK\OpenHABClient.cs" />
     <Compile Include="Services\SettingsService.cs" />

--- a/Openhab.Core/Openhab.Core.csproj
+++ b/Openhab.Core/Openhab.Core.csproj
@@ -152,7 +152,6 @@
     <Compile Include="Common\OpenHABHttpClient.cs" />
     <Compile Include="Model\OpenHabVersion.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="SDK\ErrorMessageTranslator.cs" />
     <Compile Include="SDK\IOpenHAB.cs" />
     <Compile Include="SDK\OpenHABClient.cs" />
     <Compile Include="Services\SettingsService.cs" />
@@ -208,6 +207,12 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\..\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\XamlCompiler\Microsoft.UI.Xaml.Markup.winmd</HintPath>
     </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <PRIResource Include="Strings\en-us\Errors.resw" />
+  </ItemGroup>
+  <ItemGroup>
+    <PRIResource Include="Strings\de-de\Errors.resw" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>

--- a/Openhab.Core/SDK/IOpenHAB.cs
+++ b/Openhab.Core/SDK/IOpenHAB.cs
@@ -56,6 +56,6 @@ namespace OpenHAB.Core.SDK
         /// <summary>Checks the URL reachability.</summary>
         /// <param name="connection">Defines settings for local or remote connections.</param>
         /// <returns>>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        Task<bool> CheckUrlReachability(OpenHABConnection connection);
+        Task<HttpResponseResult<bool?, ErrorTypes?>> CheckUrlReachability(OpenHABConnection connection);
     }
 }

--- a/Openhab.Core/SDK/IOpenHAB.cs
+++ b/Openhab.Core/SDK/IOpenHAB.cs
@@ -39,8 +39,8 @@ namespace OpenHAB.Core.SDK
         /// </summary>
         /// <param name="item">The item.</param>
         /// <param name="command">The Command.</param>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        Task SendCommand(OpenHABItem item, string command);
+        /// <returns>Operation result if the command was successful or not.</returns>
+        Task<HttpResponseResult<bool>> SendCommand(OpenHABItem item, string command);
 
         /// <summary>
         /// Reset the connection to the OpenHAB server after changing the settings in the app.
@@ -56,6 +56,6 @@ namespace OpenHAB.Core.SDK
         /// <summary>Checks the URL reachability.</summary>
         /// <param name="connection">Defines settings for local or remote connections.</param>
         /// <returns>>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        Task<HttpResponseResult<bool?, ErrorTypes?>> CheckUrlReachability(OpenHABConnection connection);
+        Task<HttpResponseResult<bool>> CheckUrlReachability(OpenHABConnection connection);
     }
 }

--- a/Openhab.Core/SDK/OpenHABClient.cs
+++ b/Openhab.Core/SDK/OpenHABClient.cs
@@ -45,11 +45,11 @@ namespace OpenHAB.Core.SDK
         }
 
         /// <inheritdoc/>
-        public async Task<HttpResponseResult<bool?, ErrorTypes?>> CheckUrlReachability(OpenHABConnection connection)
+        public async Task<HttpResponseResult<bool>> CheckUrlReachability(OpenHABConnection connection)
         {
             if (string.IsNullOrWhiteSpace(connection?.Url))
             {
-                return new HttpResponseResult<bool?, ErrorTypes?>(null, ErrorTypes.UrlNotDefined, null);
+                return new HttpResponseResult<bool>(false, null);
             }
 
             if (!connection.Url.EndsWith("/", StringComparison.InvariantCultureIgnoreCase))
@@ -63,30 +63,30 @@ namespace OpenHAB.Core.SDK
                 var client = _openHABHttpClient.DisposableClient(connection, settings);
                 var result = await client.GetAsync(connection.Url + "rest").ConfigureAwait(false);
 
-                if (result.IsSuccessStatusCode)
+                if (!result.IsSuccessStatusCode)
                 {
-                    return new HttpResponseResult<bool?, ErrorTypes?>(true, null, result.StatusCode);
+                    _logger.LogError($"Http request for command failed, ErrorCode:'{result.StatusCode}'");
                 }
+
+                return new HttpResponseResult<bool>(result.IsSuccessStatusCode, result.StatusCode);
             }
             catch (InvalidOperationException ex)
             {
                 _logger.LogError(ex, "CheckUrlReachability failed");
 
-                return new HttpResponseResult<bool?, ErrorTypes?>(null, ErrorTypes.HTTPError, null, ex);
+                return new HttpResponseResult<bool>(false, null, ex);
             }
             catch (HttpRequestException ex)
             {
                 _logger.LogError(ex, "CheckUrlReachability failed");
 
-                return new HttpResponseResult<bool?, ErrorTypes?>(null, ErrorTypes.HTTPError, null, ex);
+                return new HttpResponseResult<bool>(false, null, ex);
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "CheckUrlReachability failed.");
-                return new HttpResponseResult<bool?, ErrorTypes?>(null, ErrorTypes.HTTPError, null, ex);
+                return new HttpResponseResult<bool>(false, null, ex);
             }
-
-            return new HttpResponseResult<bool?, ErrorTypes?>(false, null, null);
         }
 
         /// <inheritdoc />
@@ -255,7 +255,7 @@ namespace OpenHAB.Core.SDK
         }
 
         /// <inheritdoc />
-        public async Task SendCommand(OpenHABItem item, string command)
+        public async Task<HttpResponseResult<bool>> SendCommand(OpenHABItem item, string command)
         {
             try
             {
@@ -269,18 +269,19 @@ namespace OpenHAB.Core.SDK
                 if (!result.IsSuccessStatusCode)
                 {
                     _logger.LogError($"Http request for command failed, ErrorCode:'{result.StatusCode}'");
-                    throw new OpenHABException($"{result.StatusCode} received from server");
                 }
+
+                return new HttpResponseResult<bool>(result.IsSuccessStatusCode, result.StatusCode);
             }
             catch (HttpRequestException ex)
             {
                 _logger.LogError(ex, "SendCommand failed.");
-                throw new OpenHABException("Invalid call", ex);
+                return new HttpResponseResult<bool>(false, null, ex);
             }
             catch (ArgumentNullException ex)
             {
                 _logger.LogError(ex, "SendCommand failed.");
-                throw new OpenHABException("Invalid call", ex);
+                return new HttpResponseResult<bool>(false, null, ex);
             }
         }
 
@@ -390,16 +391,16 @@ namespace OpenHAB.Core.SDK
                 return true;
             }
 
-            HttpResponseResult<bool?, ErrorTypes?> result = await CheckUrlReachability(settings.LocalConnection).ConfigureAwait(false);
+            HttpResponseResult<bool> result = await CheckUrlReachability(settings.LocalConnection).ConfigureAwait(false);
             _logger.LogInformation($"OpenHab server is reachable: {result.Content}");
 
-            if (result.Error.HasValue)
+            if (!result.Content)
             {
-                 Messenger.Default.Send<FireErrorMessage>(new FireErrorMessage(ErrorTypes.UrlNotDefined, null));
+                 Messenger.Default.Send<FireErrorMessage>(new FireErrorMessage(AppResources.Errors.GetString("ConnectionTestFailed")));
                  return false;
             }
 
-            if (result.Content.Value)
+            if (result.Content)
             {
                 OpenHABHttpClient.BaseUrl = settings.LocalConnection.Url;
                 _connection = settings.LocalConnection;
@@ -411,16 +412,16 @@ namespace OpenHAB.Core.SDK
                 // If remote URL is configured
                 if (string.IsNullOrWhiteSpace(settings.RemoteConnection?.Url))
                 {
-                    Messenger.Default.Send<FireInfoMessage>(new FireInfoMessage(MessageType.NotReachable));
+                    Messenger.Default.Send<FireErrorMessage>(new FireErrorMessage(AppResources.Errors.GetString("ConnectionTestFailed")));
                     _logger.LogWarning($"OpenHab server url is not valid");
 
                     return false;
                 }
 
                 result = await CheckUrlReachability(settings.RemoteConnection).ConfigureAwait(false);
-                if (result.Error != null || !result.Content.Value)
+                if (!result.Content)
                 {
-                    Messenger.Default.Send<FireInfoMessage>(new FireInfoMessage(MessageType.NotReachable));
+                    Messenger.Default.Send<FireErrorMessage>(new FireErrorMessage(AppResources.Errors.GetString("ConnectionTestFailed")));
                     _logger.LogWarning($"OpenHab server url is not valid");
 
                     return false;

--- a/Openhab.Core/SDK/OpenHABClient.cs
+++ b/Openhab.Core/SDK/OpenHABClient.cs
@@ -45,11 +45,11 @@ namespace OpenHAB.Core.SDK
         }
 
         /// <inheritdoc/>
-        public async Task<bool> CheckUrlReachability(OpenHABConnection connection)
+        public async Task<HttpResponseResult<bool?, ErrorTypes?>> CheckUrlReachability(OpenHABConnection connection)
         {
             if (string.IsNullOrWhiteSpace(connection?.Url))
             {
-                return false;
+                return new HttpResponseResult<bool?, ErrorTypes?>(null, ErrorTypes.UrlNotDefined, null);
             }
 
             if (!connection.Url.EndsWith("/", StringComparison.InvariantCultureIgnoreCase))
@@ -65,27 +65,28 @@ namespace OpenHAB.Core.SDK
 
                 if (result.IsSuccessStatusCode)
                 {
-                    return true;
+                    return new HttpResponseResult<bool?, ErrorTypes?>(true, null, result.StatusCode);
                 }
             }
             catch (InvalidOperationException ex)
             {
                 _logger.LogError(ex, "CheckUrlReachability failed");
 
-                return false;
+                return new HttpResponseResult<bool?, ErrorTypes?>(null, ErrorTypes.HTTPError, null, ex);
             }
             catch (HttpRequestException ex)
             {
                 _logger.LogError(ex, "CheckUrlReachability failed");
 
-                return false;
+                return new HttpResponseResult<bool?, ErrorTypes?>(null, ErrorTypes.HTTPError, null, ex);
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "CheckUrlReachability failed.");
+                return new HttpResponseResult<bool?, ErrorTypes?>(null, ErrorTypes.HTTPError, null, ex);
             }
 
-            return false;
+            return new HttpResponseResult<bool?, ErrorTypes?>(false, null, null);
         }
 
         /// <inheritdoc />
@@ -117,7 +118,7 @@ namespace OpenHAB.Core.SDK
                 }
 
                 if (!Version.TryParse(apiInfo?.RuntimeInfo.Version, out Version serverVersion))
-                 {
+                {
                     string message = "Not able to parse runtime verion from openHAB server";
                     _logger.LogError(message);
 
@@ -389,10 +390,16 @@ namespace OpenHAB.Core.SDK
                 return true;
             }
 
-            bool isReachable = await CheckUrlReachability(settings.LocalConnection).ConfigureAwait(false);
-            _logger.LogInformation($"OpenHab server is reachable: {isReachable}");
+            HttpResponseResult<bool?, ErrorTypes?> result = await CheckUrlReachability(settings.LocalConnection).ConfigureAwait(false);
+            _logger.LogInformation($"OpenHab server is reachable: {result.Content}");
 
-            if (isReachable)
+            if (result.Error.HasValue)
+            {
+                 Messenger.Default.Send<FireErrorMessage>(new FireErrorMessage(ErrorTypes.UrlNotDefined, null));
+                 return false;
+            }
+
+            if (result.Content.Value)
             {
                 OpenHABHttpClient.BaseUrl = settings.LocalConnection.Url;
                 _connection = settings.LocalConnection;
@@ -402,20 +409,28 @@ namespace OpenHAB.Core.SDK
             else
             {
                 // If remote URL is configured
-                if (!string.IsNullOrWhiteSpace(settings.RemoteConnection?.Url) &&
-                    await CheckUrlReachability(settings.RemoteConnection).ConfigureAwait(false))
+                if (string.IsNullOrWhiteSpace(settings.RemoteConnection?.Url))
                 {
-                    OpenHABHttpClient.BaseUrl = settings.RemoteConnection.Url;
-                    _connection = settings.RemoteConnection;
-                    return true;
+                    Messenger.Default.Send<FireInfoMessage>(new FireInfoMessage(MessageType.NotReachable));
+                    _logger.LogWarning($"OpenHab server url is not valid");
+
+                    return false;
                 }
 
-                Messenger.Default.Send<FireInfoMessage>(new FireInfoMessage(MessageType.NotReachable));
+                result = await CheckUrlReachability(settings.RemoteConnection).ConfigureAwait(false);
+                if (result.Error != null || !result.Content.Value)
+                {
+                    Messenger.Default.Send<FireInfoMessage>(new FireInfoMessage(MessageType.NotReachable));
+                    _logger.LogWarning($"OpenHab server url is not valid");
+
+                    return false;
+                }
+
+                OpenHABHttpClient.BaseUrl = settings.RemoteConnection.Url;
+                _connection = settings.RemoteConnection;
+
+                return true;
             }
-
-            _logger.LogWarning($"OpenHab server url is not valid");
-
-            return false;
         }
     }
 }

--- a/Openhab.Core/Strings/de-de/Errors.resw
+++ b/Openhab.Core/Strings/de-de/Errors.resw
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="CommandFailed" xml:space="preserve">
+    <value>Kommando '{0}' für Item '{1}' konnte nicht an den openHAB Server gesendet werden.</value>
+  </data>
+  <data name="ConnectionTestFailed" xml:space="preserve">
+    <value>Überprüfung der Verbindungskonfiguration des openHAB Server nicht möglich.</value>
+  </data>
+</root>

--- a/Openhab.Core/Strings/en-us/Errors.resw
+++ b/Openhab.Core/Strings/en-us/Errors.resw
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="CommandFailed" xml:space="preserve">
+    <value>Failed to send command '{0}' for item '{1}' to openHAB server.</value>
+  </data>
+  <data name="ConnectionTestFailed" xml:space="preserve">
+    <value>Unable to validate connection configuration for openHAB server.</value>
+  </data>
+</root>


### PR DESCRIPTION
- Fixed app crash when command can not be sent to server.
- Added classes to improve error handling and visualization.

Signed-off-by: Christoph Hofmann <oss@hoffe.org>